### PR TITLE
Fix Claude OAuth: use claude.ai token endpoint (console host now 404s)

### DIFF
--- a/src/providers/claude/login.rs
+++ b/src/providers/claude/login.rs
@@ -16,7 +16,7 @@ use std::fmt::Write as _;
 use std::io::Read as _;
 
 const AUTHORIZE_ENDPOINT: &str = "https://claude.ai/oauth/authorize";
-const TOKEN_ENDPOINT: &str = "https://console.anthropic.com/v1/oauth/token";
+const TOKEN_ENDPOINT: &str = "https://claude.ai/v1/oauth/token";
 const REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const SCOPE: &str = "user:profile";

--- a/src/providers/claude/oauth.rs
+++ b/src/providers/claude/oauth.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::json;
 use thiserror::Error;
 
-pub(super) const TOKEN_ENDPOINT: &str = "https://console.anthropic.com/v1/oauth/token";
+pub(super) const TOKEN_ENDPOINT: &str = "https://claude.ai/v1/oauth/token";
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Fixes #11.

Anthropic retired `https://console.anthropic.com/v1/oauth/token` — it now returns 404, so adding a Claude account fails at the code-exchange step. The subscription OAuth flow now exchanges and refreshes tokens at `https://claude.ai/v1/oauth/token`.

Same request, just the host changed, and it returns the tokens fine. The authorize endpoint and redirect URI were already correct, so only `TOKEN_ENDPOINT` needed updating — in two places (login + refresh). Tested on 0.5.0; login works again after this change.