### PR TITLE
Fix Claude OAuth login: move token endpoint to platform.claude.com

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7046,7 +7046,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yapcap"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yapcap"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MPL-2.0"
 description = "COSMIC panel applet for Codex, Claude Code, and Cursor usage"

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -49,7 +49,7 @@ read_when:
 | Provider | Primary | Fallback |
 | --- | --- | --- |
 | Codex | Active Codex account resolved from YapCap-owned `metadata.json`/`tokens.json` | Codex OAuth token refresh via `auth.openai.com/oauth/token` before expiry or once after 401/403 |
-| Claude | Active Claude account resolved from YapCap-owned `claude-accounts/<id>/` (`tokens.json`, `metadata.json`) | OAuth access-token refresh via `POST https://console.anthropic.com/v1/oauth/token` (`grant_type=refresh_token`) |
+| Claude | Active Claude account resolved from YapCap-owned `claude-accounts/<id>/` (`tokens.json`, `metadata.json`) | OAuth access-token refresh via `POST https://platform.claude.com/v1/oauth/token` (`grant_type=refresh_token`) |
 | Cursor | Active Cursor account resolved from YapCap-owned `cursor-accounts/<id>/` (`metadata.json`, `tokens.json`, optional `snapshot.json`) | — |
 | Gemini | Active Gemini account resolved from YapCap-owned `gemini-accounts/<id>/` (`metadata.json`, `tokens.json`, optional `snapshot.json`) | OAuth refresh-token grant against `oauth2.googleapis.com/token` before expiry or once after a `loadCodeAssist` / `retrieveUserQuota` 401 |
 | Copilot | Active GitHub Copilot account resolved from YapCap-owned `copilot-accounts/<id>/` (`metadata.json`, `tokens.json`) | None; token is long-lived and re-auth is user-driven after revocation |
@@ -304,7 +304,7 @@ Primary: `GET https://api.anthropic.com/api/oauth/usage` with:
 - `Authorization: Bearer <access_token>` (current access token from account `tokens.json`)
 - `anthropic-beta: oauth-2025-04-20`
 - Token must carry scope `user:profile`; otherwise `MissingProfileScope` is returned before the request.
-- Before the request, YapCap preflights token expiry. If `expires_at` is within five minutes, YapCap calls `POST https://console.anthropic.com/v1/oauth/token` with `grant_type=refresh_token`, writes updated tokens to account storage (and updates metadata when the response includes identity fields), then continues with the fresh access token and performs exactly one usage request in that cycle.
+- Before the request, YapCap preflights token expiry. If `expires_at` is within five minutes, YapCap calls `POST https://platform.claude.com/v1/oauth/token` with `grant_type=refresh_token`, writes updated tokens to account storage (and updates metadata when the response includes identity fields), then continues with the fresh access token and performs exactly one usage request in that cycle.
 - If the usage endpoint returns HTTP 401, YapCap attempts one token refresh via the same OAuth token endpoint, persists new tokens when that succeeds, and retries the usage request once immediately with the fresh access token. If the retry also returns 401, the cycle ends as unauthorized without another refresh attempt.
 
 Response shape:
@@ -322,7 +322,7 @@ Claude usage windows are partially tolerant because the endpoint can return null
 
 Usage fallback: none. Claude usage is fetched only through the OAuth usage endpoint.
 
-All routine access-token refresh uses `POST https://console.anthropic.com/v1/oauth/token` with `grant_type=refresh_token` and the stored refresh token. The Claude CLI is not involved.
+All routine access-token refresh uses `POST https://platform.claude.com/v1/oauth/token` with `grant_type=refresh_token` and the stored refresh token. The Claude CLI is not involved.
 
 HTTP 429 surfaces as `ClaudeError::RateLimited { retry_after_secs: Option<u64> }`, is marked transient, and displays the message "Rate limited by Claude — will retry automatically", optionally appended with "(retry in Xm)" when a `Retry-After` header is present. Token refresh HTTP 4xx errors other than 429 are permanent re-auth failures (`requires_user_action = true`).
 

--- a/src/providers/claude/login.rs
+++ b/src/providers/claude/login.rs
@@ -16,7 +16,7 @@ use std::fmt::Write as _;
 use std::io::Read as _;
 
 const AUTHORIZE_ENDPOINT: &str = "https://claude.ai/oauth/authorize";
-const TOKEN_ENDPOINT: &str = "https://console.anthropic.com/v1/oauth/token";
+const TOKEN_ENDPOINT: &str = "https://platform.claude.com/v1/oauth/token";
 const REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const SCOPE: &str = "user:profile";

--- a/src/providers/claude/oauth.rs
+++ b/src/providers/claude/oauth.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::json;
 use thiserror::Error;
 
-pub(super) const TOKEN_ENDPOINT: &str = "https://console.anthropic.com/v1/oauth/token";
+pub(super) const TOKEN_ENDPOINT: &str = "https://platform.claude.com/v1/oauth/token";
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Problem

Claude login fails in the YapCap GUI with:

> Claude OAuth token exchange returned 404 Not Found (grant_type=authorization_code redirect_uri=https://console.anthropic.com/oauth/code/callback …)

Anthropic migrated its OAuth **token** host from `console.anthropic.com` to `platform.claude.com` (part of the broader `*.anthropic.com` → `claude.com` rebrand). The old host now 404s, breaking both the login code exchange and routine access-token refresh.

## Verification

| Host | `POST /v1/oauth/token` |
|---|---|
| `console.anthropic.com` | **404** (retired) |
| `platform.claude.com` | 400 to a bad body (live path) |

I confirmed login works end-to-end against a native (`just install`) build after the change.

## Change

- Point `TOKEN_ENDPOINT` at `https://platform.claude.com/v1/oauth/token` in both `src/providers/claude/login.rs` (code exchange) and `src/providers/claude/oauth.rs` (refresh).
- Update the three concrete token-endpoint URLs in `docs/spec.md`.
- Bump version `0.5.0` → `0.5.1`.

## Deliberately left unchanged

- **Usage endpoint** `api.anthropic.com/api/oauth/usage` — still live (responds, not 404).
- **Authorize endpoint** (`claude.ai/oauth/authorize`) and **redirect URI** (`console.anthropic.com/oauth/code/callback`) — these still mint a valid auth code, and OAuth requires the token exchange to reuse the exact `redirect_uri` from the authorize step, so only the 404ing host was moved.
- Release-management artifacts (metainfo `<release>` entry, Flatpak source pin, docs version strings) — left for the maintainer to set at release time, matching the `just tag` convention which touches only `Cargo.toml`/`Cargo.lock`.

`just check` and `cargo test` (348 passed) are clean.